### PR TITLE
Switch Ayo AI analytics from tokens to credits, add provider/model ed…

### DIFF
--- a/src/components/AyoAI/AyoAIAnalytics.jsx
+++ b/src/components/AyoAI/AyoAIAnalytics.jsx
@@ -31,10 +31,14 @@ import {
   faMagnifyingGlass,
   faUser,
   faXmark,
+  faWallet,
+  faPenToSquare,
 } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { toast } from "react-toastify";
 import { apiClient } from "../../lib/apiClient";
+import ModalComponent from "../modals/ModalComponent";
+import EditAiProviderForm from "./EditAiProviderForm";
 
 /* ─── Formatters ─────────────────────────────────────────────── */
 const formatNumber = (value) => {
@@ -110,6 +114,7 @@ const emptySummary = {
 
 const emptyResources = {
   totalTokens: null,
+  totalCredits: null,
   inputTokens: null,
   outputTokens: null,
   totalCostUSD: null,
@@ -119,7 +124,7 @@ const emptyResources = {
   provider: null,
   model: null,
   dailyUsage: [],
-  change: { totalCostUSD: null, totalTokens: null },
+  change: { totalCostUSD: null, totalTokens: null, totalCredits: null },
 };
 
 const colors = ["#16a34a", "#3b82f6", "#8b5cf6", "#f59e0b", "#9ca3af"];
@@ -183,7 +188,7 @@ const getRadialOptions = () => ({
   colors: ["#16a34a"],
 });
 
-const getTokensBarOptions = (categories) => ({
+const getUsageBarOptions = (categories, unitLabel = "tokens") => ({
   chart: { type: "bar", toolbar: { show: false } },
   xaxis: {
     categories,
@@ -201,7 +206,7 @@ const getTokensBarOptions = (categories) => ({
   dataLabels: { enabled: false },
   grid: { borderColor: "#f3f4f6", strokeDashArray: 4 },
   plotOptions: { bar: { borderRadius: 4, columnWidth: "55%" } },
-  tooltip: { y: { formatter: (v) => `${formatTokens(v)} tokens` } },
+  tooltip: { y: { formatter: (v) => `${formatTokens(v)} ${unitLabel}` } },
 });
 
 /* ─── Nigeria map ────────────────────────────────────────────── */
@@ -278,6 +283,7 @@ const AyoAIAnalytics = () => {
   const [ayoActive, setAyoActive] = useState(null);
   const [togglingAyo, setTogglingAyo] = useState(false);
   const [pendingDeactivate, setPendingDeactivate] = useState(false);
+  const [editingProvider, setEditingProvider] = useState(false);
   const [resources, setResources] = useState(emptyResources);
   const [tokenUsage, setTokenUsage] = useState({ data: [], meta: {} });
   const [tokenUsageLoading, setTokenUsageLoading] = useState(true);
@@ -421,7 +427,7 @@ const AyoAIAnalytics = () => {
     setResettingUserId(userId);
     try {
       const res = await apiClient.post(`/admin/ai-analytics/user-token-usage/${userId}/reset`);
-      toast.success(`Quota reset for ${name}. New limit: ${formatTokens(res.data?.newLimit)} tokens.`);
+      toast.success(`Quota reset for ${name}. New limit: ${formatNumber(res.data?.newLimit)} credits.`);
       setTokenRefreshKey((k) => k + 1);
     } catch (err) {
       toast.error(err.message || "Failed to reset quota. Please try again.");
@@ -527,6 +533,14 @@ const AyoAIAnalytics = () => {
   /* Resource consumption data */
   const resourceMetrics = [
     {
+      icon: faWallet,
+      iconBg: "bg-emerald-100",
+      iconColor: "text-emerald-600",
+      label: "Total Ayo Credits",
+      value: formatNumber(resources.totalCredits),
+      sub: resources.change?.totalCredits != null ? formatChange(resources.change.totalCredits) : null,
+    },
+    {
       icon: faMicrochip,
       iconBg: "bg-violet-100",
       iconColor: "text-violet-600",
@@ -568,13 +582,13 @@ const AyoAIAnalytics = () => {
     },
   ];
 
-  const tokenBarCategories = (resources.dailyUsage || []).map((d) =>
+  const creditBarCategories = (resources.dailyUsage || []).map((d) =>
     formatDateLabel(d.date, "day")
   );
-  const tokenBarSeries = [
-    { name: "Tokens", data: (resources.dailyUsage || []).map((d) => Number(d.tokens) || 0) },
+  const creditBarSeries = [
+    { name: "Credits", data: (resources.dailyUsage || []).map((d) => Number(d.credits) || 0) },
   ];
-  const tokenBarOptions = getTokensBarOptions(tokenBarCategories);
+  const creditBarOptions = getUsageBarOptions(creditBarCategories, "credits");
   const budgetPct = Math.min(100, Math.round(resources.budgetUsedPercent || 0));
 
   const handleExport = () => {
@@ -693,13 +707,16 @@ const AyoAIAnalytics = () => {
             </div>
           ) : (
             <div className="flex items-center gap-3 shrink-0">
-              {resources.provider && (
-                <div className="hidden sm:flex items-center gap-1.5 bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5">
-                  <FontAwesomeIcon icon={faServer} className="text-gray-400 text-xs" />
-                  <span className="text-xs font-medium text-gray-600">{resources.provider}</span>
-                  {resources.model && <span className="text-xs text-gray-400">· {resources.model}</span>}
-                </div>
-              )}
+              <button
+                type="button"
+                onClick={() => setEditingProvider(true)}
+                className="hidden sm:flex items-center gap-1.5 bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 hover:border-green-300 hover:bg-green-50"
+              >
+                <FontAwesomeIcon icon={faServer} className="text-gray-400 text-xs" />
+                <span className="text-xs font-medium text-gray-600">{resources.provider || "Set AI provider"}</span>
+                {resources.model && <span className="text-xs text-gray-400">· {resources.model}</span>}
+                <FontAwesomeIcon icon={faPenToSquare} className="text-gray-400 text-[10px]" />
+              </button>
               <span className="text-xs text-gray-500 font-medium">
                 {togglingAyo ? "Updating..." : ayoActive ? "Turn off" : "Turn on"}
               </span>
@@ -1013,9 +1030,10 @@ const AyoAIAnalytics = () => {
                     : `${formatUSD((resources.monthlyBudgetUSD || 0) - (resources.totalCostUSD || 0))} remaining`}
                 </p>
 
-                {/* Token breakdown */}
+                {/* Usage breakdown */}
                 <div className="mt-4 pt-3 border-t border-gray-200 space-y-2">
                   {[
+                    { label: "Ayo credits used", value: formatNumber(resources.totalCredits), dot: "bg-emerald-500" },
                     { label: "Input tokens", value: formatTokens(resources.inputTokens), dot: "bg-blue-400" },
                     { label: "Output tokens", value: formatTokens(resources.outputTokens), dot: "bg-violet-500" },
                     { label: "Requests", value: resources.totalRequests != null ? formatNumber(resources.totalRequests) : "—", dot: "bg-green-500" },
@@ -1038,28 +1056,28 @@ const AyoAIAnalytics = () => {
             )}
           </div>
 
-          {/* Daily token usage chart */}
+          {/* Daily credit usage chart */}
           <div className="lg:col-span-3">
-            <p className="text-xs font-semibold text-gray-600 mb-3">Daily Token Usage</p>
+            <p className="text-xs font-semibold text-gray-600 mb-3">Daily Credit Usage</p>
             {loading ? (
               <div className="h-[200px] animate-pulse rounded-lg bg-gray-100" />
-            ) : tokenBarSeries[0].data.length ? (
-              <Chart options={tokenBarOptions} series={tokenBarSeries} type="bar" height={200} />
+            ) : creditBarSeries[0].data.length ? (
+              <Chart options={creditBarOptions} series={creditBarSeries} type="bar" height={200} />
             ) : (
               <div className="grid h-[200px] place-items-center rounded-lg border border-dashed border-gray-200 text-sm text-gray-400">
-                No token usage data for this period.
+                No credit usage data for this period.
               </div>
             )}
           </div>
         </div>
       </div>
 
-      {/* ── User Token Usage ────────────────────────────────────── */}
+      {/* ── User Credit Usage ────────────────────────────────────── */}
       <div className="bg-white rounded-xl shadow-[0_0_10px_#EDEDED] p-5">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5">
           <div>
-            <h2 className="font-semibold text-gray-800 text-sm">User Token Usage</h2>
-            <p className="text-xs text-gray-400 mt-0.5">Per-user Ayo AI trial quota. Reset to extend access for individual farmers.</p>
+            <h2 className="font-semibold text-gray-800 text-sm">User Credit Usage</h2>
+            <p className="text-xs text-gray-400 mt-0.5">Per-user Ayo AI trial quota, in Ayo credits. Reset to extend access for individual farmers.</p>
           </div>
         </div>
 
@@ -1092,7 +1110,7 @@ const AyoAIAnalytics = () => {
             <thead>
               <tr className="border-b border-gray-100">
                 <th className="text-left text-xs font-medium text-gray-400 pb-2 pr-4">Farmer</th>
-                <th className="text-left text-xs font-medium text-gray-400 pb-2 pr-4">Usage</th>
+                <th className="text-left text-xs font-medium text-gray-400 pb-2 pr-4">Credit Usage</th>
                 <th className="text-left text-xs font-medium text-gray-400 pb-2 pr-4">Status</th>
                 <th className="text-left text-xs font-medium text-gray-400 pb-2 pr-4">Last Active</th>
                 <th className="text-right text-xs font-medium text-gray-400 pb-2">Action</th>
@@ -1111,7 +1129,7 @@ const AyoAIAnalytics = () => {
                 ))
               ) : tokenUsage.data.length === 0 ? (
                 <tr>
-                  <td colSpan={5} className="py-10 text-center text-sm text-gray-400">No token usage records found.</td>
+                  <td colSpan={5} className="py-10 text-center text-sm text-gray-400">No credit usage records found.</td>
                 </tr>
               ) : (
                 tokenUsage.data.map((user) => (
@@ -1130,11 +1148,11 @@ const AyoAIAnalytics = () => {
                     <td className="py-3 pr-4">
                       <div className="min-w-[180px]">
                         <div className="flex justify-between text-xs mb-1">
-                          <span className="text-gray-600">{formatTokens(user.tokensUsed)} used</span>
+                          <span className="text-gray-600">{formatNumber(user.creditsUsed)} credits used</span>
                           <span className="text-gray-400">
-                            {formatTokens(user.tokenLimit)} limit
-                            {user.bonusTokens > 0 && (
-                              <span className="ml-1 text-green-600">+{formatTokens(user.bonusTokens)} bonus</span>
+                            {formatNumber(user.creditLimit)} limit
+                            {user.bonusCredits > 0 && (
+                              <span className="ml-1 text-green-600">+{formatNumber(user.bonusCredits)} bonus</span>
                             )}
                           </span>
                         </div>
@@ -1144,7 +1162,7 @@ const AyoAIAnalytics = () => {
                             style={{ width: `${Math.min(100, user.usagePercent)}%` }}
                           />
                         </div>
-                        <p className="text-[10px] text-gray-400 mt-0.5">{user.usagePercent}% · {formatTokens(user.tokensRemaining)} remaining</p>
+                        <p className="text-[10px] text-gray-400 mt-0.5">{user.usagePercent}% · {formatNumber(user.creditsRemaining)} credits remaining</p>
                       </div>
                     </td>
                     <td className="py-3 pr-4">
@@ -1251,6 +1269,27 @@ const AyoAIAnalytics = () => {
           provider invoice.
         </p>
       </div>
+
+      {/* ── Edit AI provider/model modal ─────────────────────────── */}
+      <ModalComponent
+        isModalOpen={editingProvider}
+        onClose={() => setEditingProvider(false)}
+        title="AI Provider & Model"
+        hideHeader
+      >
+        <EditAiProviderForm
+          currentProvider={resources.provider}
+          currentModel={resources.model}
+          onClose={() => setEditingProvider(false)}
+          onSaved={(updated) =>
+            setResources((prev) => ({
+              ...prev,
+              provider: updated?.provider ?? prev.provider,
+              model: updated?.model ?? prev.model,
+            }))
+          }
+        />
+      </ModalComponent>
     </div>
   );
 };

--- a/src/components/AyoAI/EditAiProviderForm.jsx
+++ b/src/components/AyoAI/EditAiProviderForm.jsx
@@ -1,0 +1,128 @@
+import { faCheckCircle, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useState } from "react";
+import { toast } from "react-toastify";
+import { apiClient } from "../../lib/apiClient";
+import { LoadingButtonContent } from "../common/LoadingStates";
+
+const PROVIDERS = [
+  { value: "AWS Bedrock", defaultModel: "amazon.nova-lite-v1:0" },
+  { value: "Gemini", defaultModel: "gemini-3.1-flash-lite" },
+];
+
+const EditAiProviderForm = ({ currentProvider, currentModel, onClose, onSaved }) => {
+  const [provider, setProvider] = useState(currentProvider || PROVIDERS[0].value);
+  const [model, setModel] = useState(currentModel || "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const selectedProviderConfig = PROVIDERS.find((p) => p.value === provider);
+  const providerChanged = provider !== currentProvider;
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!model.trim()) {
+      setError("Enter a model id for the selected provider.");
+      return;
+    }
+
+    setSaving(true);
+    setError("");
+    try {
+      const res = await apiClient.patch("/admin/ai-settings", {
+        provider,
+        model: model.trim(),
+      });
+      toast.success(`Ayo will now use ${provider} (${model.trim()}).`);
+      onSaved?.(res.data);
+      onClose?.();
+    } catch (err) {
+      const message = err.message || "Failed to update AI provider settings.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-white">
+      <div className="flex items-center justify-between border-b border-[#eef2f6] px-6 py-5">
+        <h3 className="text-lg font-semibold text-[#101828]">AI Provider & Model</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close dialog"
+          className="grid h-9 w-9 place-items-center rounded-md border border-[#d0d5dd] text-[#101828] hover:bg-[#f2f4f7]"
+        >
+          <FontAwesomeIcon icon={faXmark} />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="px-6 py-5">
+        <p className="text-sm text-[#667085]">
+          Choose which AI backend Ayo uses to generate replies. Changes take effect immediately — no redeploy needed.
+        </p>
+
+        <div className="mt-5">
+          <label className="text-sm font-semibold text-[#101828]">Provider</label>
+          <select
+            value={provider}
+            onChange={(event) => {
+              const next = event.target.value;
+              setProvider(next);
+              if (providerChanged || !model.trim()) {
+                const config = PROVIDERS.find((p) => p.value === next);
+                setModel(config?.defaultModel || "");
+              }
+            }}
+            disabled={saving}
+            className="mt-2 h-10 w-full rounded-md border border-[#d0d5dd] px-3 text-sm outline-none focus:border-[#008f45] disabled:bg-[#f9fafb]"
+          >
+            {PROVIDERS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.value}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="mt-4">
+          <label className="text-sm font-semibold text-[#101828]">Model ID</label>
+          <input
+            type="text"
+            value={model}
+            onChange={(event) => setModel(event.target.value)}
+            disabled={saving}
+            placeholder={selectedProviderConfig?.defaultModel}
+            className="mt-2 h-10 w-full rounded-md border border-[#d0d5dd] px-4 text-sm outline-none focus:border-[#008f45] disabled:bg-[#f9fafb]"
+          />
+          <p className="mt-1.5 text-xs text-[#667085]">
+            Must be a valid model id for {provider}. For example: {selectedProviderConfig?.defaultModel}.
+          </p>
+        </div>
+
+        {providerChanged && (
+          <div className="mt-4 flex items-start gap-2 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            <FontAwesomeIcon icon={faCheckCircle} className="mt-0.5 shrink-0" />
+            Switching providers — make sure the model id above matches {provider}, not the previous provider.
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-4 rounded-md bg-[#fff1f2] px-3 py-2 text-sm text-[#ef3340]">{error}</div>
+        )}
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="mt-6 inline-flex h-11 w-full items-center justify-center rounded-md bg-[#008f45] text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {saving ? <LoadingButtonContent label="Saving..." /> : "Save Provider Settings"}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default EditAiProviderForm;


### PR DESCRIPTION
…itor

Displays usage in Ayo credits instead of raw tokens for clearer farmer-facing reporting, and lets admins change the AI provider and model directly from the analytics page.